### PR TITLE
Update Python Attribute Alignment Code - Github - 3-6-23.ipynb

### DIFF
--- a/PythonCode/Python Attribute Alignment Code - Github - 3-6-23.ipynb
+++ b/PythonCode/Python Attribute Alignment Code - Github - 3-6-23.ipynb
@@ -130,7 +130,7 @@
     "    \n",
     "    for team_id, stuff in info.items():\n",
     "        if not header_printed:\n",
-    "            attribute_names = [attribute for attribute in sorted(stuff['attribute_dict'].keys())]\n",
+    "            attribute_names = [attribute for attribute in stuff['attribute_dict'].keys()]\n",
     "            metric_names = [metric for metric in sorted(stuff['metrics'].keys()) if metric != 'pairwise']\n",
     "            s = [team_id_name, outcome_column_name]\n",
     "            s += metric_names\n",


### PR DESCRIPTION
You don't sort this above in pairwise_distances so this ends up making the metrics and labels not match up. This is a bit hacky to assume the hash ordering is identical, but it is the quickest fix without passing around dicts or objects.